### PR TITLE
Add retrying HTTP client with header injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-# RedirectHunter v3
+# RedirectHunter
 
-RedirectHunter is a security-focused CLI that discovers and traces full redirect chains. It follows HTTP 3xx, JavaScript and HTML meta refreshes, then scores any risky behavior such as open redirects, token leakage, SSRF or HTTPS downgrades.
+RedirectHunter is a security-focused command-line tool that discovers and traces full redirect chains. It follows server-side HTTP 3xx, HTML meta refreshes, and JavaScript redirects, then scores any risky behaviour such as open redirects, token leakage, SSRF, or HTTPS downgrades.
 
 ## Features
-- Risk scoring on findings (low/medium/high)
-- Plugin system with built-in final URL SSRF detector
+- Severity scoring for findings (low/medium/high)
+- Plugin system with a built-in final URL SSRF detector
+- Configurable HTTP client with custom headers, cookies, and retry logic
 - HTML report with redirect chain visualisation
-- Custom header injection and cookie support
 - Redirect loop and excessive chain detection
 - Landing page phishing heuristics
-- `--silent`, `--summary` and `--only-risky` output modes
+- Output modes: default, `--silent`, `--summary`, and `--only-risky`
 - Colourised terminal output aware of hop types
-- Rate limited parallel scanning (default 10 threads)
+- Rate-limited parallel scanning (default 10 threads)
 - JSONL output format for downstream processing
 
 ## Quick start
@@ -83,7 +83,6 @@ This tool is intended for educational and authorised security testing only. Use 
 
 ## ☕ Support the Project
 
-RedirectHunter is a free and open-source tool developed with passion for the security community.  
-If you find it helpful or use it in your work, consider supporting its development ❤️
+RedirectHunter is a free and open-source tool developed with passion for the security community. If you find it helpful or use it in your work, consider supporting its development ❤️
 
 [![Buy Me a Coffee](https://img.shields.io/badge/☕-Buy%20Me%20a%20Coffee-yellow?style=for-the-badge)](https://buymeacoffee.com/iamselimozcan)

--- a/internal/httpclient/client.go
+++ b/internal/httpclient/client.go
@@ -18,6 +18,66 @@ type Config struct {
 	Retries  int
 }
 
+// headerRoundTripper wraps a base RoundTripper to inject headers/cookies and
+// perform simple retry logic.
+type headerRoundTripper struct {
+	base    http.RoundTripper
+	headers http.Header
+	cookie  string
+	retries int
+}
+
+func (h *headerRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if h.base == nil {
+		h.base = http.DefaultTransport
+	}
+
+	var resp *http.Response
+	var err error
+
+	for attempt := 0; ; attempt++ {
+		// Clone the request to avoid mutations across retries
+		r := req.Clone(req.Context())
+		if req.Body != nil {
+			if req.GetBody != nil {
+				if body, berr := req.GetBody(); berr == nil {
+					r.Body = body
+				}
+			} else {
+				r.Body = req.Body
+			}
+		}
+
+		// Inject headers and cookies
+		for k, vs := range h.headers {
+			r.Header.Del(k)
+			for _, v := range vs {
+				r.Header.Add(k, v)
+			}
+		}
+		if h.cookie != "" {
+			r.Header.Set("Cookie", h.cookie)
+		}
+
+		resp, err = h.base.RoundTrip(r)
+		if err == nil && resp.StatusCode < 500 {
+			return resp, nil
+		}
+
+		if attempt >= h.retries {
+			if err != nil {
+				return nil, err
+			}
+			return resp, nil
+		}
+
+		if resp != nil {
+			_ = resp.Body.Close()
+		}
+		time.Sleep(time.Duration(100*(1<<attempt)) * time.Millisecond)
+	}
+}
+
 // New returns a configured HTTP client with manual redirect handling.
 func New(cfg Config) *http.Client {
 	transport := &http.Transport{
@@ -31,8 +91,13 @@ func New(cfg Config) *http.Client {
 	}
 
 	client := &http.Client{
-		Transport: transport,
-		Timeout:   cfg.Timeout,
+		Transport: &headerRoundTripper{
+			base:    transport,
+			headers: cfg.Headers,
+			cookie:  cfg.Cookie,
+			retries: cfg.Retries,
+		},
+		Timeout: cfg.Timeout,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			// prevent automatic redirects
 			return http.ErrUseLastResponse

--- a/internal/httpclient/client_test.go
+++ b/internal/httpclient/client_test.go
@@ -1,0 +1,86 @@
+package httpclient
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestHeaderInjection(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Test") != "1" {
+			t.Fatalf("expected header injected")
+		}
+		if r.Header.Get("Cookie") != "token=abc" {
+			t.Fatalf("expected cookie injected")
+		}
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+
+	cfg := Config{
+		Timeout: 1 * time.Second,
+		Headers: http.Header{"X-Test": []string{"1"}},
+		Cookie:  "token=abc",
+	}
+	client := New(cfg)
+	resp, err := client.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp.Body.Close()
+}
+
+func TestRetry(t *testing.T) {
+	t.Run("5xx", func(t *testing.T) {
+		attempts := 0
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			attempts++
+			if attempts < 3 {
+				w.WriteHeader(500)
+				return
+			}
+			w.WriteHeader(200)
+		}))
+		defer srv.Close()
+
+		client := New(Config{Timeout: 1 * time.Second, Retries: 2})
+		resp, err := client.Get(srv.URL)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.StatusCode != 200 {
+			t.Fatalf("expected final 200, got %d", resp.StatusCode)
+		}
+		if attempts != 3 {
+			t.Fatalf("expected 3 attempts, got %d", attempts)
+		}
+		resp.Body.Close()
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		attempts := 0
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			attempts++
+			if attempts == 1 {
+				hj, _ := w.(http.Hijacker)
+				conn, _, _ := hj.Hijack()
+				conn.Close()
+				return
+			}
+			w.WriteHeader(200)
+		}))
+		defer srv.Close()
+
+		client := New(Config{Timeout: 1 * time.Second, Retries: 1})
+		resp, err := client.Get(srv.URL)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if attempts != 2 {
+			t.Fatalf("expected 2 attempts, got %d", attempts)
+		}
+		resp.Body.Close()
+	})
+}


### PR DESCRIPTION
- wrap transport with custom RoundTripper to inject headers and cookies on every request
- implement configurable retry logic with exponential backoff for network errors and 5xx responses
- add unit tests for header injection and retry behavior
- rewrite README to highlight features, flags, and development workflow